### PR TITLE
Release: slate-connector-canvas v1.4.0

### DIFF
--- a/.holo/branches/emergence-layer/_slate-connector-canvas.toml
+++ b/.holo/branches/emergence-layer/_slate-connector-canvas.toml
@@ -1,0 +1,4 @@
+
+[holomapping]
+files = "*/**"
+after = "*"

--- a/.holo/branches/emergence-site/_slate-connector-canvas.toml
+++ b/.holo/branches/emergence-site/_slate-connector-canvas.toml
@@ -1,0 +1,5 @@
+
+[holomapping]
+holosource = "=>emergence-layer"
+files = "**"
+after = "*"

--- a/.holo/branches/emergence-site/_slate.toml
+++ b/.holo/branches/emergence-site/_slate.toml
@@ -1,0 +1,3 @@
+[holomapping]
+files = "*/**"
+before = "*"

--- a/.holo/config.toml
+++ b/.holo/config.toml
@@ -1,0 +1,2 @@
+[holospace]
+name = "slate-connector-canvas"

--- a/.holo/sources/slate.toml
+++ b/.holo/sources/slate.toml
@@ -1,0 +1,3 @@
+[holosource]
+url = "https://github.com/SlateFoundation/slate"
+ref = "refs/heads/emergence/skeleton/v2"

--- a/.studiorc
+++ b/.studiorc
@@ -1,0 +1,3 @@
+#!/bin/bash
+hab pkg install emergence/studio chakijs/studio
+source "$(hab pkg path emergence/studio)/studio.sh"

--- a/php-classes/RemoteSystems/Canvas.php
+++ b/php-classes/RemoteSystems/Canvas.php
@@ -2,6 +2,8 @@
 
 namespace RemoteSystems;
 
+use RuntimeException;
+
 class Canvas
 {
     public static $canvasHost;
@@ -53,7 +55,19 @@ class Canvas
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 
         $response = json_decode(curl_exec($ch), true);
+        $responseCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
         curl_close($ch);
+
+        if ($responseCode >= 400 || $responseCode < 200) {
+            throw new \RuntimeException(
+                (
+                    !empty($response['errors']) ?
+                    'Canvas reports: '.$response['errors'][0]['message']
+                    : 'unknown Canvas error'
+                ),
+                $responseCode
+            );
+        }
 
         return $response;
     }

--- a/php-classes/RemoteSystems/Canvas.php
+++ b/php-classes/RemoteSystems/Canvas.php
@@ -72,6 +72,14 @@ class Canvas
         return $response;
     }
 
+    /**
+     * Format a timestamp to a format that will string-match what Canvas returns
+     */
+    public static function formatTimestamp($timestamp)
+    {
+        return gmdate('Y-m-d\TH:i:s\Z', $timestamp);
+    }
+
 
     // Accounts: https://canvas.instructure.com/doc/api/accounts.html
     public static function getAccount($accountID = null)

--- a/php-classes/Slate/Connectors/Canvas/Connector.php
+++ b/php-classes/Slate/Connectors/Canvas/Connector.php
@@ -1020,6 +1020,7 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                                 'sectionCode' => $Section->Code
                             ]
                         );
+                        continue;
                     } else {
                         $courseMappingData['ExternalIdentifier'] = $canvasResponse['id'];
                         $CourseMapping = Mapping::create($courseMappingData, true);
@@ -1162,6 +1163,7 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                                 'canvasResponse' => $canvasResponse
                             ]
                         );
+                        continue;
                     } else {
                         $sectionMappingData['ExternalIdentifier'] = $canvasResponse['id'];
                         $SectionMapping = Mapping::create($sectionMappingData, true);

--- a/php-classes/Slate/Connectors/Canvas/Connector.php
+++ b/php-classes/Slate/Connectors/Canvas/Connector.php
@@ -14,7 +14,7 @@ use Emergence\Connectors\IIdentityConsumer;
 use Emergence\Connectors\ISynchronize;
 use Emergence\EventBus;
 
-use Emergence\Connectors\Job;
+use Emergence\Connectors\IJob;
 use Emergence\Connectors\Mapping;
 use Emergence\People\IPerson;
 use Emergence\People\Person;
@@ -187,7 +187,7 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
         return $config;
     }
 
-    public static function synchronize(Job $Job, $pretend = true)
+    public static function synchronize(IJob $Job, $pretend = true)
     {
         if ($Job->Status != 'Pending' && $Job->Status != 'Completed') {
             return static::throwError('Cannot execute job, status is not Pending or Complete');
@@ -244,7 +244,7 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
 
     // task handlers
 
-    public static function pushUsers(Job $Job, $pretend = true)
+    public static function pushUsers(IJob $Job, $pretend = true)
     {
         $conditions = [
             'AccountLevel IS NOT NULL AND ( (AccountLevel NOT IN ("Disabled", "Contact", "User", "Staff")) OR (Class = "Slate\\\\People\\\\Student" AND AccountLevel != "Disabled") )', // no disabled accounts, non-users, guests, and non-teaching staff
@@ -875,7 +875,7 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
     // use job as logger and update log method
     // log all api calls
     // update references to createSectionEnrollment & removeSectionEnrollment
-    public static function pushSections(Job $Job, $pretend = true)
+    public static function pushSections(IJob $Job, $pretend = true)
     {
         if (empty($Job->Config['masterTerm'])) {
             $Job->logException(new Exception('masterTerm required to import sections'));

--- a/php-classes/Slate/Connectors/Canvas/Connector.php
+++ b/php-classes/Slate/Connectors/Canvas/Connector.php
@@ -2,6 +2,8 @@
 
 namespace Slate\Connectors\Canvas;
 
+use RuntimeException;
+
 use Psr\Log\LogLevel;
 use Psr\Log\LoggerInterface;
 
@@ -1048,7 +1050,20 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                     ]
                 );
 
-                $canvasCourse = CanvasAPI::getCourse($CourseMapping->ExternalIdentifier);
+                try {
+                    $canvasCourse = CanvasAPI::getCourse($CourseMapping->ExternalIdentifier);
+                } catch (RuntimeException $e) {
+                    $results['failed']['courses']++;
+                    $Job->error(
+                        'Failed to fetch Canvas course {canvasId}: {canvasError} (status: {canvasStatus})',
+                        [
+                            'canvasId' => $CourseMapping->ExternalIdentifier,
+                            'canvasError' => $e->getMessage(),
+                            'canvasStatus' => $e->getCode()
+                        ]
+                    );
+                    continue;
+                }
 
                 $canvasFrom = [];
                 $canvasTo = [];

--- a/php-classes/Slate/Connectors/Canvas/Connector.php
+++ b/php-classes/Slate/Connectors/Canvas/Connector.php
@@ -772,7 +772,9 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                     $SectionMapping,
                     $logger,
                     $enrollmentType,
-                    $observeeId
+                    [
+                        'associated_user_id' => $observeeId
+                    ]
                 );
             } elseif (ucfirst($enrollmentType).'Enrollment' != $canvasEnrollments[$SectionMapping->ExternalIdentifier]['type']) {
                 if ($pretend) {
@@ -1276,7 +1278,7 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                     'observers' => []
                 ];
 
-                // get all enrollments, sort by type and index by username
+                // get all current canvas enrollments, sort by type and index by username
                 foreach (CanvasAPI::getEnrollmentsBySection($SectionMapping->ExternalIdentifier) as $canvasEnrollment) {
                     if ($canvasEnrollment['type'] == 'TeacherEnrollment') {
                         $canvasEnrollments['teachers'][$canvasEnrollment['user']['sis_user_id']] = $canvasEnrollment;
@@ -1287,17 +1289,34 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                     }
                 }
 
+                // get all current slate enrollments, sort by type and index by username
+                foreach (SectionParticipant::getAllByField('CourseSectionID', $Section->ID) as $SectionParticipant) {
+                    switch ($SectionParticipant->Role) {
+                        case 'Observer':
+                            $slateEnrollments['observers'][$SectionParticipant->Person->Username] = $SectionParticipant;
+                            break;
+                        case 'Student':
+                            $slateEnrollments['students'][$SectionParticipant->Person->Username] = $SectionParticipant;
+                            break;
+                        case 'Assistant':
+                        case 'Teacher':
+                            $slateEnrollments['teachers'][$SectionParticipant->Person->Username] = $SectionParticipant;
+                            break;
+                    }
+                }
+
                 // add teachers to canvas
-                foreach ($Section->Teachers as $Teacher) {
-                    $slateEnrollments['teachers'][] = $Teacher->Username;
+                foreach ($slateEnrollments['teachers'] as $teacherUsername => $SectionParticipant) {
                     $results['analyzed']['enrollments']++;
+
                     // check if teacher needs enrollment
-                    $enrollTeacher = !array_key_exists($Teacher->Username, $canvasEnrollments['teachers']);
+                    $enrollTeacher = !array_key_exists($teacherUsername, $canvasEnrollments['teachers']);
+
                     if ($enrollTeacher) {
                         if (!$pretend) {
                             try {
                                 $newEnrollment = static::createSectionEnrollment(
-                                    $Teacher,
+                                    $SectionParticipant->Person,
                                     $SectionMapping,
                                     $Job,
                                     'teacher'
@@ -1311,7 +1330,7 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                                 'Enrolling {enrollmentType} {slateUsername} into course section {sectionCode}',
                                 [
                                     'sectionCode' => $Section->Code,
-                                    'slateUsername' => $Teacher->Username,
+                                    'slateUsername' => $teacherUsername,
                                     'enrollmentType' => 'teacher'
                                 ]
                             );
@@ -1321,8 +1340,14 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
 
                 // remove teachers from canvas
                 if (!empty($Job->Config['removeTeachers'])) {
-                    foreach (array_diff(array_keys($canvasEnrollments['teachers']), $slateEnrollments['teachers']) as $teacherUsername) {
+                    $teachersToRemove = array_diff(
+                        array_keys($canvasEnrollments['teachers']),
+                        array_keys($slateEnrollments['teachers'])
+                    );
+
+                    foreach ($teachersToRemove as $teacherUsername) {
                         $enrollmentId = $canvasEnrollments['teachers'][$teacherUsername]['id'];
+
                         if ($Teacher = User::getByUsername($teacherUsername)) { // todo: handle accounts deleted in slate?
                             if (!$pretend) {
                                 try {
@@ -1341,7 +1366,7 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                                     'Removing {enrollmentType} enrollment for {slateUsername} from course section {sectionCode}',
                                     [
                                         'sectionCode' => $Section->Code,
-                                        'slateUsername' => $Teacher->Username,
+                                        'slateUsername' => $teacherUsername,
                                         'enrollmentType' => 'teacher'
                                     ]
                                 );
@@ -1351,18 +1376,45 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                 }
 
                 // add students to canvas
-                foreach ($Section->Students as $Student) {
-                    $slateEnrollments['students'][] = $Student->Username;
-                    $enrollStudent = !array_key_exists($Student->Username, $canvasEnrollments['students']);
+                foreach ($slateEnrollments['students'] as $studentUsername => $SectionParticipant) {
+                    $results['analyzed']['enrollments']++;
+
+                    $enrollStudent = !array_key_exists($studentUsername, $canvasEnrollments['students']);
+
+                    if ($SectionParticipant->StartDate) {
+                        $startAt = CanvasAPI::formatTimestamp($SectionParticipant->StartDate);
+                    } else {
+                        $startAt = null;
+                    }
+
+                    if ($SectionParticipant->EndDate) {
+                        // treat "empty" time component as end of day
+                        if (date('H:i:s', $SectionParticipant->EndDate) == '00:00:00') {
+                            $endAt = CanvasAPI::formatTimestamp($SectionParticipant->EndDate + (60*60*24-1));
+                        } else {
+                            $endAt = CanvasAPI::formatTimestamp($SectionParticipant->EndDate);
+                        }
+
+                        // end_at will be ignored if start_at isn't set too
+                        if (!$startAt) {
+                            $startAt = CanvasAPI::formatTimestamp(strtotime($Section->Term->StartDate));
+                        }
+                    } else {
+                        $endAt = null;
+                    }
 
                     if ($enrollStudent) {
                         if (!$pretend) {
                             try {
                                 $newEnrollment = static::createSectionEnrollment(
-                                    $Student,
+                                    $SectionParticipant->Person,
                                     $SectionMapping,
                                     $Job,
-                                    'student'
+                                    'student',
+                                    [
+                                        'start_at' => $startAt,
+                                        'end_at' => $endAt
+                                    ]
                                 );
                             } catch (SyncException $e) {
                                 $Job->logException($e);
@@ -1372,10 +1424,59 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                                 'Enrolling {enrollmentType} {slateUsername} into course section {sectionCode}',
                                 [
                                     'sectionCode' => $Section->Code,
-                                    'slateUsername' => $Student->Username,
+                                    'slateUsername' => $studentUsername,
                                     'enrollmentType' => 'student'
                                 ]
                             );
+                        }
+                    } else {
+                        $canvasEnrollment = $canvasEnrollments['students'][$studentUsername];
+                        $changes = [];
+
+                        if ($canvasEnrollment['start_at'] != $startAt) {
+                            $changes['start_at'] = [
+                                'from' => $canvasEnrollment['start_at'],
+                                'to' => $startAt
+                            ];
+                        }
+
+                        if ($canvasEnrollment['end_at'] != $endAt) {
+                            $changes['end_at'] = [
+                                'from' => $canvasEnrollment['end_at'],
+                                'to' => $endAt
+                            ];
+                        }
+
+                        if (!empty($changes)) {
+                            $Job->notice(
+                                'Updating enrollment for {enrollmentType} {slateUsername} in course section {sectionCode}',
+                                [
+                                    'action' => 'update',
+                                    'changes' => $changes,
+                                    'sectionCode' => $Section->Code,
+                                    'slateUsername' => $studentUsername,
+                                    'enrollmentType' => 'student'
+                                ]
+                            );
+
+                            if (!$pretend) {
+                                try {
+                                    $updatedEnrollment = static::createSectionEnrollment(
+                                        $SectionParticipant->Person,
+                                        $SectionMapping,
+                                        $Job,
+                                        'student',
+                                        [
+                                            'start_at' => $startAt,
+                                            'end_at' => $endAt
+                                        ]
+                                    );
+                                } catch (SyncException $e) {
+                                    $Job->logException($e);
+                                }
+                            }
+
+                            $results['updated']['sections']++;
                         }
                     }
 
@@ -1407,9 +1508,9 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                         //                             $Guardian,
                         //                             $CourseMapping,
                         //                             $SectionMapping,
+                        //                             'observer',
                         //                             [
-                        //                                 'type' => 'observer',
-                        //                                 'observeeId' => $studentCanvasId
+                        //                                 'associated_user_id' => $studentCanvasId
                         //                             ]
                         //                         )
                         //                     );
@@ -1450,8 +1551,14 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                 }
 
                 // remove students from canvas
-                foreach (array_diff(array_keys($canvasEnrollments['students']), $slateEnrollments['students']) as $studentUsername) {
+                $studentsToRemove = array_diff(
+                    array_keys($canvasEnrollments['students']),
+                    array_keys($slateEnrollments['students'])
+                );
+
+                foreach ($studentsToRemove as $studentUsername) {
                     $enrollmentId = $canvasEnrollments['students'][$studentUsername]['id'];
+
                     if ($Student = Student::getByUsername($studentUsername)) { // todo: handle accounts deleted in slate?
                         if (!$pretend) {
                             try {
@@ -1470,7 +1577,7 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
                                 'Removing {enrollmentType} enrollment for {slateUsername} from course section {sectionCode}',
                                 [
                                     'sectionCode' => $Section->Code,
-                                    'slateUsername' => $Student->Username,
+                                    'slateUsername' => $studentUsername,
                                     'enrollmentType' => 'student'
                                 ]
                             );
@@ -1493,7 +1600,7 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
     * @param $settings array - Config array containing enrollment options
     * @return SyncResult object / SyncException object
     */
-    protected static function createSectionEnrollment(IPerson $User, Mapping $SectionMapping, LoggerInterface $logger, $enrollmentType, $observeeId = null)
+    protected static function createSectionEnrollment(IPerson $User, Mapping $SectionMapping, LoggerInterface $logger, $enrollmentType, array $enrollmentData = [])
     {
         switch ($enrollmentType) {
             case 'student':
@@ -1508,20 +1615,20 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
         $canvasUserId = static::_getCanvasUserID($User->ID);
 
         try {
-            $enrollmentData = [
+            $requestData = [
                 'enrollment[user_id]' => $canvasUserId,
                 'enrollment[type]' => ucfirst($enrollmentType).'Enrollment',
                 'enrollment[enrollment_state]' => 'active',
                 'enrollment[notify]' => 'false',
             ];
 
-            if ($enrollmentType == 'observer' && !empty($observeeId)) {
-                $enrollmentData['enrollment[associated_user_id]'] = $observeeId;
+            foreach ($enrollmentData as $enrollmentKey => $enrollmentValue) {
+                $requestData["enrollment[{$enrollmentKey}]"] = $enrollmentValue;
             }
 
             $canvasResponse = CanvasAPI::createEnrollmentsForSection(
                 $SectionMapping->ExternalIdentifier,
-                $enrollmentData
+                $requestData
             );
 
             $logger->notice(

--- a/php-classes/Slate/Connectors/Canvas/Connector.php
+++ b/php-classes/Slate/Connectors/Canvas/Connector.php
@@ -10,8 +10,6 @@ use Site;
 use RemoteSystems\Canvas as CanvasAPI;
 
 
-use Emergence\Connectors\AbstractConnector;
-use Emergence\Connectors\IdentityConsumerTrait;
 use Emergence\Connectors\IIdentityConsumer;
 use Emergence\Connectors\ISynchronize;
 use Emergence\EventBus;
@@ -32,14 +30,8 @@ use Slate\Courses\Section;
 use Slate\Courses\SectionParticipant;
 use Slate\People\Student;
 
-class Connector extends AbstractConnector implements ISynchronize, IIdentityConsumer
+class Connector extends SAML2Connector implements ISynchronize, IIdentityConsumer
 {
-    use IdentityConsumerTrait {
-        getSAMLNameId as getDefaultSAMLNameId;
-        getLaunchUrl as getDefaultLaunchUrl;
-    }
-
-
     public static $sectionSkipper;
     public static $sectionTitleBuilder = [__CLASS__, 'buildSectionTitle'];
 
@@ -74,7 +66,7 @@ class Connector extends AbstractConnector implements ISynchronize, IIdentityCons
             'Person' => $Person
         ]);
 
-        return SAML2Connector::handleLoginRequest($Person, __CLASS__);
+        return parent::handleLoginRequest($Person, __CLASS__);
     }
 
     public static function userIsPermitted(IPerson $Person)
@@ -153,7 +145,7 @@ class Connector extends AbstractConnector implements ISynchronize, IIdentityCons
             ];
         }
 
-        return static::getDefaultSAMLNameId($Person);
+        return parent::getSAMLNameId($Person);
     }
 
     public static function getLaunchUrl(Mapping $Mapping = null)
@@ -162,7 +154,7 @@ class Connector extends AbstractConnector implements ISynchronize, IIdentityCons
             return static::getBaseUrl() . '/launch?course=' . $Mapping->ExternalIdentifier;
         }
 
-        return static::getDefaultLaunchUrl($Mapping);
+        return parent::getLaunchUrl($Mapping);
     }
 
     public static function buildSectionTitle(Section $Section)
@@ -953,7 +945,7 @@ class Connector extends AbstractConnector implements ISynchronize, IIdentityCons
                 );
                 continue;
             }
-            
+
             $canvasSection = null;
 
             // build section title

--- a/php-config/RemoteSystems/Canvas.config.php
+++ b/php-config/RemoteSystems/Canvas.config.php
@@ -1,0 +1,5 @@
+<?php
+
+#RemoteSystems\Canvas::$canvasHost = 'slatedemo.instructure.com';
+#RemoteSystems\Canvas::$apiToken = 'YOUR_API_TOKEN_HERE';
+#RemoteSystems\Canvas::$accountID = 1;


### PR DESCRIPTION
- feat: add emergence-site and -layer holobranches
- feat: add emergence studio
- feat: push enrollment-level start/end dates to Canvas
- fix: skip remaining stages of section sync on error
- fix: throw errors on failed canvas requests
- refactor: merge example canvas config from slate repo