### PR TITLE
Release: slate-connector-canvas v1.7.0

### DIFF
--- a/.holo/branches/emergence-site/_slate.toml
+++ b/.holo/branches/emergence-site/_slate.toml
@@ -1,3 +1,4 @@
 [holomapping]
-files = "*/**"
+holosource = "=>emergence-skeleton"
+files = "**"
 before = "*"

--- a/.holo/sources/slate.toml
+++ b/.holo/sources/slate.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate"
-ref = "refs/heads/emergence/skeleton/v2"
+ref = "refs/heads/releases/v2"

--- a/php-classes/Slate/Connectors/Canvas/Connector.php
+++ b/php-classes/Slate/Connectors/Canvas/Connector.php
@@ -31,6 +31,7 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
 {
     public static $sectionSkipper;
     public static $sectionTitleBuilder = [__CLASS__, 'buildSectionTitle'];
+    public static $sectionTitleTermPrefix = true;
 
     public static $title = 'Canvas';
     public static $connectorId = 'canvas';
@@ -154,13 +155,25 @@ class Connector extends SAML2Connector implements ISynchronize, IIdentityConsume
 
     public static function buildSectionTitle(Section $Section)
     {
-        $sectionTitle = $Section->Title;
+        if (static::$sectionTitleTermPrefix) {
+            $masterTerm = $Section->Term->getMaster();
+            $year1 = substr($masterTerm->StartDate, 2, 2);
+            $year2 = substr($masterTerm->EndDate, 2, 2);
 
-        if ($Section->Schedule) {
-            $sectionTitle .= ' ('.$Section->Schedule->Title.')';
+            $title = " {$year1}";
+
+            if ($year1 != $year2) {
+                $title .= "–{$year2}";
+            }
+
+            $title .= ': ';
+        } else {
+            $title = '';
         }
 
-        return $sectionTitle;
+        $title .= $Section->getTitle();
+
+        return $title;
     }
 
     public static function synchronize(IJob $Job, $pretend = true)


### PR DESCRIPTION
## Improvements

- feat: prefix canvas section titles with master term by default @themightychris 

## Technical

- refactor(ci): use projected parent from releases/v2 branch @themightychris 