### PR TITLE
fix(api): send User-Agent header on Canvas API requests

### DIFF
--- a/php-classes/RemoteSystems/Canvas.php
+++ b/php-classes/RemoteSystems/Canvas.php
@@ -36,6 +36,7 @@ class Canvas
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($ch, CURLOPT_HEADER, true);
+            curl_setopt($ch, CURLOPT_USERAGENT, 'Slate/2.21.6');
         }
 
 


### PR DESCRIPTION
## Summary

Instructure began rejecting Canvas API requests that lack a `User-Agent` header ([community thread](https://community.instructure.com/en/discussion/658205/enforcing-user-agent-header-for-canvas-api-requests)). Since this connector's cURL wrapper never set one, every API call started failing — most visibly crashing SAML SSO logins mid-flight, when `Connector::beforeAuthenticate` pushes enrollments before returning the assertion.

This sets a static `User-Agent` on the shared cURL handle.

## Verification

The identical one-line hotfix was applied directly to the two live VFS deployments (sla-cc-live, sla-b-live) on 2026-07-21: `/connectors/canvas/login` flipped from 500 to 200 immediately on both, restoring Canvas logins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)